### PR TITLE
Implement Asynchronous JavaScript calls with Promise support

### DIFF
--- a/Engine/src/cef/BrowserMessageHandler.cpp
+++ b/Engine/src/cef/BrowserMessageHandler.cpp
@@ -1,22 +1,61 @@
-﻿#include "BrowserMessageHandler.h"
+﻿#include "pch/enginepch.h"
+#include "BrowserMessageHandler.h"
 #include "RendererMessageHandler.h"
-#include "utils/Common.h"
 
-void BrowserMessageHandler::registerCallback(const std::string& name, const std::function<void(const CefRefPtr<CefListValue>&)>& callback) {
+void BrowserMessageHandler::registerCallback(const std::string& name, const std::function<void(const Callback& callback)>& callback) {
     callbacks[name] = callback;
 }
 
 bool BrowserMessageHandler::processMessage(const CefRefPtr<CefBrowser>& browser, const CefRefPtr<CefFrame>& frame, CefProcessId sourceProcess,
                                            const CefRefPtr<CefProcessMessage>& message) {
-    const CefString& messageName = message->GetName();
-    const auto it = this->callbacks.find(messageName.ToString());
-    if (it != this->callbacks.end()) {
-        it->second(message->GetArgumentList());
-        return true;
+    if (message->GetName() == RendererMessageHandler::callName) {
+        const CefRefPtr<CefListValue> arguments = message->GetArgumentList();
+        const std::string name = arguments->GetString(0);
+        const int callId = arguments->GetInt(1);
+
+        const auto it = this->callbacks.find(name);
+        if (it != this->callbacks.end()) {
+            const Callback callback(name, callId, browser);
+            it->second(callback);
+            return true;
+        }
+        Callback(name, callId, browser).error("No callback registered for message: " + name);
     }
     return false;
 }
 
 Ref<ProcessMessageBuilder> BrowserMessageHandler::createMessage(const std::string& name) {
     return std::make_shared<ProcessMessageBuilder>(RendererMessageHandler::messageListenerName, name);
+}
+
+void Callback::success() const {
+    this->sendMessage(this->getMessageBuilder(RendererMessageHandler::callName));
+}
+
+void Callback::success(const bool value) const {
+    auto builder = this->getMessageBuilder(RendererMessageHandler::callName);
+    builder.appendBool(value);
+    this->sendMessage(builder);
+}
+
+void Callback::success(const CefRefPtr<CefListValue>& arguments) const {
+    auto builder = this->getMessageBuilder(RendererMessageHandler::callName);
+    builder.appendArguments(arguments);
+    this->sendMessage(builder);
+}
+
+void Callback::error(const std::string& error) const {
+    auto builder = this->getMessageBuilder(RendererMessageHandler::callErrorName);
+    builder.appendString(error);
+    this->sendMessage(builder);
+}
+
+ProcessMessageBuilder Callback::getMessageBuilder(const std::string& messageName) const {
+    auto message = ProcessMessageBuilder(messageName, name);
+    message.appendInt(callId);
+    return message;
+}
+
+void Callback::sendMessage(const ProcessMessageBuilder& builder) const {
+    this->browser->GetMainFrame()->SendProcessMessage(PID_RENDERER, builder.getMessage());
 }

--- a/Engine/src/cef/BrowserMessageHandler.cpp
+++ b/Engine/src/cef/BrowserMessageHandler.cpp
@@ -1,4 +1,6 @@
 ﻿#include "BrowserMessageHandler.h"
+#include "RendererMessageHandler.h"
+#include "utils/Common.h"
 
 void BrowserMessageHandler::registerCallback(const std::string& name, const std::function<void(const CefRefPtr<CefListValue>&)>& callback) {
     callbacks[name] = callback;
@@ -13,4 +15,8 @@ bool BrowserMessageHandler::processMessage(const CefRefPtr<CefBrowser>& browser,
         return true;
     }
     return false;
+}
+
+Ref<ProcessMessageBuilder> BrowserMessageHandler::createMessage(const std::string& name) {
+    return std::make_shared<ProcessMessageBuilder>(RendererMessageHandler::messageListenerName, name);
 }

--- a/Engine/src/cef/BrowserMessageHandler.h
+++ b/Engine/src/cef/BrowserMessageHandler.h
@@ -1,5 +1,11 @@
 ﻿#pragma once
 #include "cef_v8.h"
+#include <functional>
+
+#include "utils/Common.h"
+
+
+class ProcessMessageBuilder;
 
 class BrowserMessageHandler {
     friend class OSRCefHandler;
@@ -12,6 +18,30 @@ protected:
 
     bool processMessage(const CefRefPtr<CefBrowser>& browser, const CefRefPtr<CefFrame>& frame, CefProcessId sourceProcess, const CefRefPtr<CefProcessMessage>& message);
 
+    static Ref<ProcessMessageBuilder> createMessage(const std::string& name);
+
 private:
     std::unordered_map<std::string, std::function<void(const CefRefPtr<CefListValue>&)>> callbacks;
+};
+
+class ProcessMessageBuilder {
+    friend class BrowserMessageHandler;
+public:
+    ProcessMessageBuilder(const std::string& messageType, const std::string& name) : message(CefProcessMessage::Create(messageType)) {
+        arguments = message->GetArgumentList();
+        arguments->SetString(index++, name);
+    }
+
+    CefRefPtr<CefProcessMessage> getMessage() const {
+        return message;
+    }
+
+    void appendDouble(const double value) {
+        arguments->SetDouble(index++, value);
+    }
+
+private:
+    CefRefPtr<CefProcessMessage> message;
+    CefRefPtr<CefListValue> arguments;
+    unsigned int index = 0;
 };

--- a/Engine/src/cef/OSRCefApp.cpp
+++ b/Engine/src/cef/OSRCefApp.cpp
@@ -22,6 +22,7 @@ void OSRCefApp::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFra
     const CefRefPtr<CefV8Value> object = context->GetGlobal();
     object->SetValue("setMessageListener", CefV8Value::CreateFunction("setMessageListener", this->messageHandler), V8_PROPERTY_ATTRIBUTE_NONE);
     object->SetValue("sendMessage", CefV8Value::CreateFunction("sendMessage", this->messageHandler), V8_PROPERTY_ATTRIBUTE_NONE);
+    object->SetValue("cefCall", CefV8Value::CreateFunction("cefCall", this->messageHandler), V8_PROPERTY_ATTRIBUTE_NONE);
 }
 
 void OSRCefApp::OnContextReleased(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefRefPtr<CefV8Context> context) {

--- a/Engine/src/cef/OSRCefApp.cpp
+++ b/Engine/src/cef/OSRCefApp.cpp
@@ -21,7 +21,6 @@ void OSRCefApp::OnBeforeCommandLineProcessing(const CefString& processType, cons
 void OSRCefApp::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefRefPtr<CefV8Context> context) {
     const CefRefPtr<CefV8Value> object = context->GetGlobal();
     object->SetValue("setMessageListener", CefV8Value::CreateFunction("setMessageListener", this->messageHandler), V8_PROPERTY_ATTRIBUTE_NONE);
-    object->SetValue("sendMessage", CefV8Value::CreateFunction("sendMessage", this->messageHandler), V8_PROPERTY_ATTRIBUTE_NONE);
     object->SetValue("cefCall", CefV8Value::CreateFunction("cefCall", this->messageHandler), V8_PROPERTY_ATTRIBUTE_NONE);
 }
 

--- a/Engine/src/cef/OSRCefHandler.cpp
+++ b/Engine/src/cef/OSRCefHandler.cpp
@@ -153,11 +153,10 @@ void OSRCefHandler::updateFrameInfo(const double deltaTime) const {
         return;
     }
 
-    const auto message = CefProcessMessage::Create(CefString("updateFrameInfo"));
-    const auto args = message->GetArgumentList();
-    args->SetDouble(0, deltaTime);
-
-    this->host->GetBrowser()->GetMainFrame()->SendProcessMessage(PID_RENDERER, message);
+   
+    const auto args = BrowserMessageHandler::createMessage("updateFrameInfo");
+    args->appendDouble(deltaTime);
+    this->host->GetBrowser()->GetMainFrame()->SendProcessMessage(PID_RENDERER, args->getMessage());
 }
 
 void OSRCefHandler::OnLoadStart(const CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, TransitionType transitionType) {

--- a/Engine/src/cef/OSRCefHandler.h
+++ b/Engine/src/cef/OSRCefHandler.h
@@ -32,7 +32,7 @@ public:
     void sendKeyReleasedEvent(const KeyReleasedEvent& event) const;
     void sendCharTypedEvent(const CharTypedEvent& event) const;
 
-    void registerCallback(const std::string& name, const std::function<void(const CefRefPtr<CefListValue>&)>& callback) {
+    void registerCallback(const std::string& name, const std::function<void(const Callback&)>& callback) {
         this->browserMessageHandler.registerCallback(name, callback);
     }
 

--- a/Engine/src/cef/ProcessMessageBuilder.cpp
+++ b/Engine/src/cef/ProcessMessageBuilder.cpp
@@ -1,0 +1,15 @@
+﻿#include "pch/enginepch.h"
+#include "ProcessMessageBuilder.h"
+
+ProcessMessageBuilder::ProcessMessageBuilder(const std::string& messageType, const std::string& name) : message(CefProcessMessage::Create(messageType)) {
+    arguments = message->GetArgumentList();
+    arguments->SetString(index++, name);
+}
+
+void ProcessMessageBuilder::appendArguments(const CefRefPtr<CefListValue>& args) {
+    const int size = static_cast<int>(args->GetSize());
+    arguments->SetSize(size + index);
+    for (int i = 0; i < size; i++) {
+        arguments->SetValue(index++, args->GetValue(i));
+    }
+}

--- a/Engine/src/cef/ProcessMessageBuilder.h
+++ b/Engine/src/cef/ProcessMessageBuilder.h
@@ -1,0 +1,36 @@
+﻿#pragma once
+#include "cef_v8.h"
+
+class ProcessMessageBuilder {
+    friend class BrowserMessageHandler;
+
+public:
+    ProcessMessageBuilder(const std::string& messageType, const std::string& name);
+
+    CefRefPtr<CefProcessMessage> getMessage() const {
+        return message;
+    }
+
+    void appendBool(const bool value) {
+        arguments->SetBool(index++, value);
+    }
+
+    void appendInt(const int value) {
+        arguments->SetInt(index++, value);
+    }
+
+    void appendDouble(const double value) {
+        arguments->SetDouble(index++, value);
+    }
+
+    void appendString(const std::string& value) {
+        arguments->SetString(index++, value);
+    }
+
+    void appendArguments(const CefRefPtr<CefListValue>& args);
+
+private:
+    CefRefPtr<CefProcessMessage> message;
+    CefRefPtr<CefListValue> arguments;
+    unsigned int index = 0;
+};

--- a/Engine/src/cef/RendererMessageHandler.cpp
+++ b/Engine/src/cef/RendererMessageHandler.cpp
@@ -1,7 +1,39 @@
 ﻿#include "RendererMessageHandler.h"
 
+#include <limits>
+
+
 bool RendererMessageHandler::Execute(const CefString& name, CefRefPtr<CefV8Value> object, const CefV8ValueList& arguments, CefRefPtr<CefV8Value>& retVal, CefString& exception) {
-    if (name == "setMessageListener") {
+    if (name == "cefCall") {
+        // call(functionName, onSuccess, onError, args...)
+        if (arguments.size() > 2 && arguments[0]->IsString() && arguments[1]->IsFunction() && arguments[2]->IsFunction()) {
+            const CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
+            CallPromise promise;
+            promise.context = context;
+            promise.resolve = arguments[1];
+            promise.reject = arguments[2];
+            const CefRefPtr<CefBrowser> browser = context->GetBrowser();
+            const int browserId = browser->GetIdentifier();
+            if (this->callId >= INT_MAX) {
+                this->callId = INT_MIN;
+            }
+            const int callId = this->callId++;
+            this->calls.insert(std::make_pair(std::make_pair(browserId, callId), promise));
+
+            const CefRefPtr<CefProcessMessage> message = CefProcessMessage::Create(callName);
+            const CefRefPtr<CefListValue> list = message->GetArgumentList();
+            const int size = static_cast<int>(arguments.size());
+            list->SetSize(size - 2);
+            list->SetInt(0, callId);
+            list->SetString(1, arguments[0]->GetStringValue());
+            for (int i = 3; i < size; i++) {
+                if (arguments[i]->IsValid()) {
+                    setListValue(list, i - 3, arguments[i]);
+                }
+            }
+            browser->GetMainFrame()->SendProcessMessage(PID_BROWSER, message);
+        }
+    } else if (name == "setMessageListener") {
         if (arguments.size() == 2 && arguments[0]->IsString() && arguments[1]->IsFunction()) {
             std::string messageName = arguments[0]->GetStringValue();
             CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
@@ -32,9 +64,19 @@ void RendererMessageHandler::releaseContext(const CefRefPtr<CefV8Context>& conte
     // Remove any JavaScript callbacks registered for the context that has been released.
     if (!this->callbacks.empty()) {
         for (auto it = this->callbacks.begin(); it != this->callbacks.end();) {
-            if (it->second.first->IsSame(context))
+            if (it->second.first->IsSame(context)) {
                 this->callbacks.erase(it++);
-            else {
+            } else {
+                ++it;
+            }
+        }
+    }
+    // Remove any pending calls for the context that has been released.
+    if (!this->calls.empty()) {
+        for (auto it = this->calls.begin(); it != this->calls.end();) {
+            if (it->second.context->IsSame(context)) {
+                this->calls.erase(it++);
+            } else {
                 ++it;
             }
         }
@@ -124,10 +166,21 @@ void RendererMessageHandler::setList(const CefRefPtr<CefListValue>& source, cons
 }
 
 bool RendererMessageHandler::processMessage(const CefRefPtr<CefBrowser>& browser, const CefRefPtr<CefFrame>& frame, CefProcessId sourceProcess,
-                                      const CefRefPtr<CefProcessMessage>& message) {
-    bool handled = false;
+                                            const CefRefPtr<CefProcessMessage>& message) {
     const CefString& messageName = message->GetName();
-    const auto it = this->callbacks.find(std::make_pair(messageName.ToString(), browser->GetIdentifier()));
+    if (messageName == callName) {
+        // return processMessageForCall(browser, message);
+    } else if (messageName == messageListenerName) {
+        return processMessageForListener(browser, message);
+    }
+    return false;
+}
+
+bool RendererMessageHandler::processMessageForListener(const CefRefPtr<CefBrowser>& browser, const CefRefPtr<CefProcessMessage>& message) {
+    const CefRefPtr<CefListValue> list = message->GetArgumentList();
+    const CefString& listenerName = list->GetString(0);
+
+    const auto it = this->callbacks.find(std::make_pair(listenerName.ToString(), browser->GetIdentifier()));
     if (it != this->callbacks.end()) {
         // Keep a local reference to the objects. The callback may remove itself from the callback map.
         const CefRefPtr<CefV8Context> context = it->second.first;
@@ -136,22 +189,20 @@ bool RendererMessageHandler::processMessage(const CefRefPtr<CefBrowser>& browser
         context->Enter();
 
         CefV8ValueList arguments;
-        const CefRefPtr<CefListValue> list = message->GetArgumentList();
         const int size = static_cast<int>(list->GetSize());
         const CefRefPtr<CefV8Value> args = CefV8Value::CreateArray(size);
         setList(list, args);
-        arguments.reserve(list->GetSize());
-        for (int i = 0; i < size; i++) {
+        arguments.reserve(list->GetSize() - 1);
+        for (int i = 1; i < size; i++) {
             arguments.push_back(args->GetValue(i));
         }
 
         const CefRefPtr<CefV8Value> retVal = callback->ExecuteFunction(nullptr, arguments);
-        if (retVal.get()) {
-            if (retVal->IsBool())
-                handled = retVal->GetBoolValue();
+        if (retVal.get() && retVal->IsBool()) {
+            return retVal->GetBoolValue();
         }
 
         context->Exit();
     }
-    return handled;
+    return false;
 }

--- a/Engine/src/cef/RendererMessageHandler.cpp
+++ b/Engine/src/cef/RendererMessageHandler.cpp
@@ -40,21 +40,6 @@ bool RendererMessageHandler::Execute(const CefString& name, CefRefPtr<CefV8Value
             this->callbacks.insert(std::make_pair(std::make_pair(messageName, browserId), std::make_pair(context, arguments[1])));
             return true;
         }
-    } else if (name == "sendMessage") {
-        if (!arguments.empty() && arguments[0]->IsString()) {
-            const CefRefPtr<CefProcessMessage> message = CefProcessMessage::Create(arguments[0]->GetStringValue());
-            const CefRefPtr<CefListValue> list = message->GetArgumentList();
-            const int size = static_cast<int>(arguments.size());
-            list->SetSize(size - 1);
-            for (int i = 1; i < size; i++) {
-                if (arguments[i]->IsValid()) {
-                    setListValue(list, i - 1, arguments[i]);
-                }
-            }
-            const CefRefPtr<CefBrowser> browser = CefV8Context::GetCurrentContext()->GetBrowser();
-            browser->GetMainFrame()->SendProcessMessage(PID_BROWSER, message);
-            return true;
-        }
     }
     return false;
 }

--- a/Engine/src/cef/RendererMessageHandler.h
+++ b/Engine/src/cef/RendererMessageHandler.h
@@ -9,6 +9,7 @@ class RendererMessageHandler : public CefV8Handler {
 public:
     static inline const std::string messageListenerName = "__messageListener";
     static inline const std::string callName = "__call";
+    static inline const std::string callErrorName = "__callError";
 
 protected:
     RendererMessageHandler() = default;
@@ -23,6 +24,8 @@ private:
     static void setList(const CefV8ValueList& source, const CefRefPtr<CefListValue>& target);
     static void setList(const CefRefPtr<CefListValue>& source, const CefRefPtr<CefV8Value>& target);
 
+    bool processMessageForCall(const CefRefPtr<CefBrowser>& browser, const CefRefPtr<CefProcessMessage>& message);
+    bool processMessageForCallError(const CefRefPtr<CefBrowser>& browser, const CefRefPtr<CefProcessMessage>& message);
     bool processMessageForListener(const CefRefPtr<CefBrowser>& browser, const CefRefPtr<CefProcessMessage>& message);
 
     struct CallPromise {
@@ -42,7 +45,7 @@ private:
     };
 
     std::unordered_map<std::pair<std::string, int>, std::pair<CefRefPtr<CefV8Context>, CefRefPtr<CefV8Value>>, PairHash> callbacks;
-    std::unordered_map<std::pair<int, unsigned int>, CallPromise, PairHash> calls;
+    std::unordered_map<std::pair<int, int>, CallPromise, PairHash> calls;
     int callId = 0;
 
     IMPLEMENT_REFCOUNTING(RendererMessageHandler);

--- a/Engine/src/editor/scripts/UIScript.cpp
+++ b/Engine/src/editor/scripts/UIScript.cpp
@@ -53,9 +53,10 @@ void UIScript::onSpawn() {
         this->handler->sendCharTypedEvent(event);
     });
 
-    this->handler->registerCallback("toggleVSync", [this](const CefRefPtr<CefListValue>&) {
+    this->handler->registerCallback("toggleVSync", [this](const Callback& callback) {
         const bool vsync = this->app->getWindow()->isVSync();
         this->app->getWindow()->setVSync(!vsync);
+        callback.success(!vsync);
     });
 
     static bool hasFocus = false;

--- a/ui/env.d.ts
+++ b/ui/env.d.ts
@@ -4,6 +4,8 @@ declare global {
   interface Window {
     setMessageListener: (message: string, callback: Function) => void;
     sendMessage: (message: string, ...args: any[]) => void;
+    call: (name: string, ...args: any[]) => Promise<any>;
+    cefCall: (name: string, resolve: Function, reject: Function, ...args: any[]) => void;
   }
 }
 

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -16,4 +16,15 @@ window.sendMessage ??= ((message, ...args) => {
   console.log('Binding not found: sendMessage', message, args);
 });
 
+window.call = ((message, ...args) => {
+  return new Promise((resolve, reject) => {
+    window.cefCall(message, resolve, reject, args);
+  });
+});
+
+window.cefCall ??= ((name, resolve, reject) => {
+  console.log('Binding not found: cefCall', name);
+  reject(new Error('Binding not found: cefCall'));
+});
+
 app.mount('#app');

--- a/ui/src/views/HomeView.vue
+++ b/ui/src/views/HomeView.vue
@@ -15,7 +15,7 @@ function toggleVSync() {
     .then((vsync) => message.value = 'VSync toggled to: ' + vsync)
     .catch((e) => {
       // message.value = 'Failed to toggle VSync';
-      message.value = e;
+      message.value = 'Error ' + e;
     });
 }
 </script>

--- a/ui/src/views/HomeView.vue
+++ b/ui/src/views/HomeView.vue
@@ -8,8 +8,15 @@ window.setMessageListener('updateFrameInfo', (dT: number) => {
   deltaTime.value = dT;
 });
 
+const message = ref('<>');
+
 function toggleVSync() {
-  window.sendMessage('toggleVSync');
+  window.call('toggleVSync')
+    .then((vsync) => message.value = 'VSync toggled to: ' + vsync)
+    .catch((e) => {
+      // message.value = 'Failed to toggle VSync';
+      message.value = e;
+    });
 }
 </script>
 
@@ -19,5 +26,6 @@ function toggleVSync() {
     <button @click="toggleVSync" class="mt-2 px-2 py-1 bg-gray-700 hover:bg-gray-800 text-gray-50 rounded shadow">
       Toggle VSync
     </button>
+    <pre>{{ message }}</pre>
   </div>
 </template>


### PR DESCRIPTION
Removes old `sendMessage` and adds a new `cefCall` that supports success callback with arguments and failure callback. It is wrapped with a Promise in JS via `call`.